### PR TITLE
update the hook strings to ones that appear to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ are fired.
 Simply declare npm scripts with a name of the form `hook:EVENT` where `EVENT` is
 the name of a serverless hook event, i.e.:
 
-* `hook:before:offline:start`: Run script before serverless offline launches.
+* `hook:before:offline:start:init`: Run script before serverless offline launches.
   This can be particularly useful to setup the local environment, such as launching
   a local kinesis and initializing it by creating some streams.
+* `hook:offline:start:ready`: Run post-startup script, e.g. seed s3 files.
 * `hook:after:offline:start`: Run cleanup scripts after serverless offline terminates.
 * `hook:before:package:initialize`: Run script before the packaging initialization.
 


### PR DESCRIPTION
1. `hook:before:offline:start` is not being triggered for me, but `hook:before:offline:start:init` is being triggered at the appropriate "before serverless" time.
2. `hook:offline:start:ready` may be useful to anyone needing to do setup after serverless starts up.
3. I can't get `hook:after:offline:start` (or `offline:start:end`) hooks to trigger, so I'm not sure it's still valid, or if there's a way to trigger a shutdown that I'm not aware of.